### PR TITLE
DataFactory::Literal in rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://projet.liris.cnrs.fr/repid/
 - Start a web server that resorts to the Sophia backend : `./wasm_example/run_server.sh`
 
 
+
 ## Liens utiles
 
 
@@ -91,6 +92,14 @@ Normalement on est pas censé utiliser la commande `wasm-bindgen`
 
 
 
+### Test suite pour RDF JS
+
+Community group RDF JS
+
+- Faire une test suite : https://github.com/rubensworks/jest-rdf
+
+- https://www.w3.org/community/rdfjs/
+
 
 
 ### Misc
@@ -165,6 +174,10 @@ Quelques pistes à explorer :
 
 - Générer du code typescript https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-rust-exports/typescript_custom_section.html
 - Faire de la reflexion / introspection https://docs.rs/js-sys/0.3.35/js_sys/Reflect/index.html
+    - Creuser la piste de l'introspection
+
+
+    - https://github.com/rustwasm/wasm-bindgen/issues/1906
 
 Pour le moment j'ajoute une fonction javascript à la main dans le code généré
 qui fait la vérification et appelle la bonne fonction wasm
@@ -180,6 +193,10 @@ dataset plus adapté selon si l'utilisateur vient de faire beaucoup de match ou
 beaucoup de modifications du graphe (sans que l'utilisateur ne s'en rende
 compte)
 
+> Retourner this
+
+    - La piste du script Python est bof (autant ajouter à la main lors d'une
+    release les quelques lignes à générer)
 
 
 

--- a/wasm_example/run_server.sh
+++ b/wasm_example/run_server.sh
@@ -5,5 +5,5 @@ set -e
 cargo +nightly build --target wasm32-unknown-unknown
 wasm-bindgen target/wasm32-unknown-unknown/debug/wasm_example.wasm --out-dir .
 wasm-bindgen --target no-modules target/wasm32-unknown-unknown/debug/wasm_example.wasm --out-dir .
-python3 js_integrate_polymorphism.py
+# python3 js_integrate_polymorphism.py
 npm run serve

--- a/wasm_example/src/lib.rs
+++ b/wasm_example/src/lib.rs
@@ -118,7 +118,7 @@ impl JSDataset{
             }
         ).unwrap();
 
-        // TOOD : return this
+        // TODO : return this
     }
 
     #[wasm_bindgen(js_name="delete")]
@@ -274,7 +274,7 @@ impl BJTerm {
 
 // Implementation of the RDF JS specification
 // https://rdf.js.org/data-model-spec/#term-interface
-// Every term type is implemented as a BJTerm except DefaultGraph
+// Every term type is implemented as a BJTerm
 #[wasm_bindgen(js_class="Term")]
 impl BJTerm {
     #[wasm_bindgen]
@@ -605,6 +605,26 @@ impl Clone for BJDataFactory {
 
 #[wasm_bindgen(js_class=DataFactory)]
 impl BJDataFactory {
+
+    #[wasm_bindgen(js_name="literal")]
+    pub fn literal(&self, value: String, language_or_datatype: Option<JsValue>) -> BJTerm {
+        let placeholder = self.literal_from_string(value.clone(), "http://www.w3.org/2001/XMLSchema#string".into());
+
+        match language_or_datatype {
+            None => self.literal_from_string(value, "http://www.w3.org/2001/XMLSchema#string".into()),
+            Some(js_value) => {
+                match js_value.as_string() {
+                    Some(language) => self.literal_from_string(value, language),
+                    None => self.literal_from_named_node(value, js_value.into())
+                }
+            }
+        }
+    }
+}
+
+
+#[wasm_bindgen(js_class=DataFactory)]
+impl BJDataFactory {
     #[wasm_bindgen(constructor)]
     pub fn new() -> BJDataFactory {
         BJDataFactory{ }
@@ -621,6 +641,10 @@ impl BJDataFactory {
         // TODO : "If the value parameter is undefined a new identifier for the blank node is generated for each call."
         BJTerm { term: Some(RcTerm::new_bnode(value.unwrap().to_string()).unwrap()) }
     }
+
+    // #[wasm_bindgen(js_name="literal")]
+
+
 
     // Literal literal(string value, optional (string or NamedNode) languageOrDatatype);
 

--- a/wasm_example/src/lib.rs
+++ b/wasm_example/src/lib.rs
@@ -607,16 +607,13 @@ impl Clone for BJDataFactory {
 impl BJDataFactory {
 
     #[wasm_bindgen(js_name="literal")]
-    pub fn literal(&self, value: String, language_or_datatype: Option<JsValue>) -> BJTerm {
-        let placeholder = self.literal_from_string(value.clone(), "http://www.w3.org/2001/XMLSchema#string".into());
-
-        match language_or_datatype {
-            None => self.literal_from_string(value, "http://www.w3.org/2001/XMLSchema#string".into()),
-            Some(js_value) => {
-                match js_value.as_string() {
-                    Some(language) => self.literal_from_string(value, language),
-                    None => self.literal_from_named_node(value, js_value.into())
-                }
+    pub fn literal(&self, value: String, language_or_datatype: JsValue) -> BJTerm {
+        if language_or_datatype.is_null() || language_or_datatype.is_undefined() {
+            self.literal_from_string(value, "http://www.w3.org/2001/XMLSchema#string".into())
+        } else {
+            match language_or_datatype.as_string() {
+                Some(language) => self.literal_from_string(value, language),
+                None => self.literal_from_named_node(value, language_or_datatype.into())
             }
         }
     }


### PR DESCRIPTION
This merge removes the needs to use a python script to manage String / NamedNode polymorphism required by RDF JS on the literal function in data factories (the polymorphism is managed by Rust using JsValue's functions).